### PR TITLE
Use sparse matrices

### DIFF
--- a/conmech/dynamics/dynamics.py
+++ b/conmech/dynamics/dynamics.py
@@ -21,7 +21,9 @@
 from typing import Optional
 
 import numpy as np
+import scipy.sparse
 
+from conmech.struct.types import FeatureMatrix
 from conmech.dynamics.factory.dynamics_factory_method import (
     get_dynamics,
     get_basic_matrices,
@@ -99,11 +101,6 @@ class Dynamics:
     def asembly_w_matrix_with_density(self, elements_density: np.ndarray):
         # COO accumulation: one (row, col) entry per (element, i, j); scipy sums
         # duplicates on CSR construction.
-        # pylint: disable=import-outside-toplevel
-        import scipy.sparse
-
-        from conmech.struct.types import FeatureMatrix
-
         elements = self.body.mesh.elements
         nodes_count = self.body.mesh.nodes_count
         dim, _, elements_count, element_size, _ = self._local_stifness_matrices.shape

--- a/conmech/dynamics/dynamics.py
+++ b/conmech/dynamics/dynamics.py
@@ -1,3 +1,23 @@
+# CONMECH @ Jagiellonian University in Kraków
+#
+# Copyright (C) 2022-2026  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
+# Copyright (C) 2022  Michał Jureczka <michal.jureczka@uj.edu.pl>
+# Copyright (C) 2023 Wiktor Prządka
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 from typing import Optional
 
 import numpy as np
@@ -52,7 +72,8 @@ class Dynamics:
             self._w_matrix,
             self._local_stifness_matrices,
         ) = get_basic_matrices(
-            elements=self.body.mesh.elements, nodes=self.body.mesh.nodes
+            elements=self.body.mesh.elements,
+            nodes=self.body.mesh.nodes,
         )  # + self.displacement_old)
 
         if elements_density is not None:
@@ -76,15 +97,46 @@ class Dynamics:
         )
 
     def asembly_w_matrix_with_density(self, elements_density: np.ndarray):
-        w_matrix = np.zeros_like(self._w_matrix)
-        for element_index, element in enumerate(self.body.mesh.elements):
-            for i, global_i in enumerate(element):
-                for j, global_j in enumerate(element):
-                    w_matrix[:, :, global_i, global_j] += (
-                        elements_density[element_index]
-                        * self._local_stifness_matrices[:, :, element_index, i, j]
-                    )
-        return w_matrix
+        # COO accumulation: one (row, col) entry per (element, i, j); scipy sums
+        # duplicates on CSR construction.
+        # pylint: disable=import-outside-toplevel
+        import scipy.sparse
+
+        from conmech.struct.types import FeatureMatrix
+
+        elements = self.body.mesh.elements
+        nodes_count = self.body.mesh.nodes_count
+        dim, _, elements_count, element_size, _ = self._local_stifness_matrices.shape
+
+        nnz = elements_count * element_size * element_size
+        rows = np.empty(nnz, dtype=np.int64)
+        cols = np.empty(nnz, dtype=np.int64)
+        entry = 0
+        for element in elements:
+            for global_i in element:
+                for global_j in element:
+                    rows[entry] = global_i
+                    cols[entry] = global_j
+                    entry += 1
+
+        blocks = []
+        for k in range(dim):
+            row_blocks = []
+            for m in range(dim):
+                data = np.empty(nnz, dtype=np.double)
+                entry = 0
+                for element_index in range(elements_count):
+                    scale = elements_density[element_index]
+                    lsm = self._local_stifness_matrices[k, m, element_index]
+                    for i in range(element_size):
+                        for j in range(element_size):
+                            data[entry] = scale * lsm[i, j]
+                            entry += 1
+                row_blocks.append(
+                    scipy.sparse.csr_matrix((data, (rows, cols)), shape=(nodes_count, nodes_count))
+                )
+            blocks.append(row_blocks)
+        return FeatureMatrix(blocks)
 
     def relaxation(self, time: float = 0):
         # TODO handle others

--- a/conmech/dynamics/factory/_abstract_dynamics_factory.py
+++ b/conmech/dynamics/factory/_abstract_dynamics_factory.py
@@ -1,7 +1,28 @@
+# CONMECH @ Jagiellonian University in Kraków
+#
+# Copyright (C) 2022-2026  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 from typing import Tuple
-import numpy as np
 
-from conmech.struct.stiffness_matrix import SM1
+import numpy as np
+import scipy.sparse
+
+from conmech.struct.stiffness_matrix import StiffnessMatrix, SM1
+from conmech.struct.types import FeatureVector, FeatureMatrix
 
 
 class AbstractDynamicsFactory:
@@ -13,32 +34,34 @@ class AbstractDynamicsFactory:
         raise NotImplementedError()
 
     def calculate_constitutive_matrices(
-        self, W: np.ndarray, mu: float, lambda_: float
-    ) -> np.ndarray:
+        self, W: FeatureMatrix, mu: float, lambda_: float
+    ) -> StiffnessMatrix:
         raise NotImplementedError()
 
-    def get_relaxation_tensor(self, W: np.ndarray, coeff: np.ndarray):
+    def get_relaxation_tensor(self, W: FeatureMatrix, coeff: np.ndarray) -> StiffnessMatrix:
         raise NotImplementedError()
 
-    def calculate_acceleration(self, U: np.ndarray, density: float) -> np.ndarray:
+    def calculate_acceleration(self, U: scipy.sparse.spmatrix, density: float) -> StiffnessMatrix:
         raise NotImplementedError()
 
-    def calculate_thermal_expansion(self, V: np.ndarray, coeff: np.ndarray) -> np.ndarray:
+    def calculate_thermal_expansion(self, V: FeatureVector, coeff: np.ndarray) -> StiffnessMatrix:
         raise NotImplementedError()
 
-    def calculate_thermal_conductivity(self, W: np.ndarray, coeff: np.ndarray) -> np.ndarray:
+    def calculate_thermal_conductivity(
+        self, W: FeatureMatrix, coeff: np.ndarray
+    ) -> StiffnessMatrix:
         raise NotImplementedError()
 
-    def get_piezoelectric_tensor(self, W: np.ndarray, coeff: np.ndarray) -> np.ndarray:
+    def get_piezoelectric_tensor(self, W: FeatureMatrix, coeff: np.ndarray) -> StiffnessMatrix:
         raise NotImplementedError()
 
-    def get_permittivity_tensor(self, W: np.ndarray, coeff: np.ndarray) -> np.ndarray:
+    def get_permittivity_tensor(self, W: FeatureMatrix, coeff: np.ndarray) -> StiffnessMatrix:
         raise NotImplementedError()
 
     @staticmethod
-    def calculate_poisson_matrix(W: np.ndarray, propagation: float) -> SM1:
-        return SM1(propagation**2 * np.sum(W.diagonal(), axis=2))
+    def calculate_poisson_matrix(W: FeatureMatrix, propagation: float) -> SM1:
+        return SM1(propagation**2 * W.diagonal_sum())
 
     @staticmethod
-    def calculate_wave_matrix(W: np.ndarray) -> np.ndarray:
-        return np.sum(W.diagonal(), axis=2)
+    def calculate_wave_matrix(W: FeatureMatrix) -> scipy.sparse.spmatrix:
+        return W.diagonal_sum()

--- a/conmech/dynamics/factory/_dynamics_factory_2d.py
+++ b/conmech/dynamics/factory/_dynamics_factory_2d.py
@@ -1,8 +1,28 @@
+# CONMECH @ Jagiellonian University in Kraków
+#
+# Copyright (C) 2022-2026  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
+# Copyright (C) 2022  Michał Jureczka <michal.jureczka@uj.edu.pl>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 # pylint: disable=R0914
 import numba
 import numpy as np
 
 from conmech.dynamics.factory._abstract_dynamics_factory import AbstractDynamicsFactory
+from conmech.helpers.assembly import block, hstack_blocks, coo_features_to_csr
 from conmech.struct.stiffness_matrix import SM2, SM1, SM1to2
 
 DIMENSION = 2
@@ -15,14 +35,22 @@ VOLUME_DIVIDER = 2
 
 
 @numba.njit
-def get_edges_features_matrix_numba(elements, nodes):
-    # integral of phi over the element (in 2D: 1/3, in 3D: 1/4)
-    nodes_count = len(nodes)
-    elements_count, element_size = elements.shape
+def get_edges_features_matrix_coo_numba(elements, nodes):
+    """Assemble node features in COO form.
 
-    edges_features_matrix = np.zeros(
-        (FEATURE_MATRIX_COUNT, nodes_count, nodes_count), dtype=np.double
-    )
+    Contains integral of phi over the element (in 2D: 1/3, in 3D: 1/4).
+    Returns the COO triplets ``(rows, cols, data)`` with ``data`` of shape
+    ``(FEATURE_MATRIX_COUNT, nnz)`` where ``nnz = elements_count * element_size**2``.
+    Duplicate ``(row, col)`` entries are *not* summed here - that is left to
+    ``scipy.sparse`` (which sums duplicates on construction).
+    """
+    elements_count, element_size = elements.shape
+    nnz = elements_count * element_size * element_size
+
+    rows = np.empty(nnz, dtype=np.int64)
+    cols = np.empty(nnz, dtype=np.int64)
+    data = np.zeros((FEATURE_MATRIX_COUNT, nnz), dtype=np.double)
+
     element_initial_volume = np.zeros(elements_count)
     # Local stifness matrices (w[0, 0], w[0, 1], w[1, 0], w[1, 1]) per mesh element
     # Detailed description can be found in [LSM] Local stifness matrix
@@ -32,7 +60,8 @@ def get_edges_features_matrix_numba(elements, nodes):
 
     en0 = np.empty(ELEMENT_NODES_COUNT)
     en1 = np.empty(ELEMENT_NODES_COUNT)
-    for element_index in range(elements_count):  # TODO: #65 prange?
+    entry = 0
+    for element_index in range(elements_count):
         element = elements[element_index]
         element_nodes = nodes[element]
 
@@ -105,7 +134,9 @@ def get_edges_features_matrix_numba(elements, nodes):
 
                 local_stifness_matrices[:, :, element_index, i, j] = element_volume * np.asarray(w)
 
-                edges_features_matrix[:, element[i], element[j]] += element_volume * np.array(
+                rows[entry] = element[i]
+                cols[entry] = element[j]
+                data[:, entry] = element_volume * np.array(
                     [
                         volume_at_nodes,
                         u,
@@ -118,9 +149,9 @@ def get_edges_features_matrix_numba(elements, nodes):
                         q / element_volume,
                     ]
                 )
+                entry += 1
 
-    # Performance TIP: we need only sparse, triangular matrix (?)
-    return edges_features_matrix, element_initial_volume, local_stifness_matrices
+    return rows, cols, data, element_initial_volume, local_stifness_matrices
 
 
 @numba.njit
@@ -154,7 +185,11 @@ def denominator_numba(x_i, x_j1, x_j2):
 
 class DynamicsFactory2D(AbstractDynamicsFactory):
     def get_edges_features_matrix(self, elements, nodes):
-        return get_edges_features_matrix_numba(elements, nodes)
+        rows, cols, data, element_initial_volume, local_stifness_matrices = (
+            get_edges_features_matrix_coo_numba(elements, nodes)
+        )
+        features = coo_features_to_csr(rows, cols, data, len(nodes))
+        return features, element_initial_volume, local_stifness_matrices
 
     @property
     def dimension(self) -> int:
@@ -165,23 +200,22 @@ class DynamicsFactory2D(AbstractDynamicsFactory):
         A_12 = mu * W[1, 0] + lambda_ * W[0, 1]
         A_21 = lambda_ * W[1, 0] + mu * W[0, 1]
         A_22 = mu * W[0, 0] + (2 * mu + lambda_) * W[1, 1]
-        return SM2(np.block([[A_11, A_12], [A_21, A_22]]))
+        return SM2(block([[A_11, A_12], [A_21, A_22]]))
 
     def get_relaxation_tensor(self, W, coeff):
         A_11 = coeff[0][0][0] * W[0, 0] + coeff[0][1][1] * W[1, 1]
         A_12 = coeff[0][1][0] * W[1, 0] + coeff[0][0][1] * W[0, 1]
         A_21 = coeff[1][1][0] * W[1, 0] + coeff[1][0][1] * W[0, 1]
         A_22 = coeff[1][0][0] * W[0, 0] + coeff[1][1][1] * W[1, 1]
-        return SM2(np.block([[A_11, A_12], [A_21, A_22]]))
+        return SM2(block([[A_11, A_12], [A_21, A_22]]))
 
     def calculate_acceleration(self, U, density):
-        Z = np.zeros_like(U)
-        return SM2(density * np.block([[U, Z], [Z, U]]))
+        return SM2(density * block([[U, None], [None, U]]))
 
     def calculate_thermal_expansion(self, V, coeff):
         A_11 = coeff[0][0] * V[0] + coeff[0][1] * V[1]
         A_22 = coeff[1][0] * V[0] + coeff[1][1] * V[1]
-        return SM1to2(np.block([A_11, A_22]))
+        return SM1to2(hstack_blocks([A_11, A_22]))
 
     def calculate_thermal_conductivity(self, W, coeff):
         return SM1(
@@ -196,7 +230,7 @@ class DynamicsFactory2D(AbstractDynamicsFactory):
         A_12 = coeff[0][1][0] * W[1, 0] + coeff[0][0][1] * W[0, 1]
         A_21 = coeff[1][1][0] * W[1, 0] + coeff[1][0][1] * W[0, 1]
         A_22 = coeff[1][0][0] * W[0, 0] + coeff[1][1][1] * W[1, 1]
-        return SM2(np.block([[A_11 + A_12, A_22 + A_21]]))
+        return SM2(hstack_blocks([A_11 + A_12, A_22 + A_21]))
 
     def get_permittivity_tensor(self, W, coeff):
         return SM1(

--- a/conmech/dynamics/factory/_dynamics_factory_3d.py
+++ b/conmech/dynamics/factory/_dynamics_factory_3d.py
@@ -1,7 +1,27 @@
+# CONMECH @ Jagiellonian University in Kraków
+#
+# Copyright (C) 2022-2026  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
+# Copyright (C) 2022  Michał Jureczka <michal.jureczka@uj.edu.pl>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 import numba
 import numpy as np
 
 from conmech.dynamics.factory._abstract_dynamics_factory import AbstractDynamicsFactory
+from conmech.helpers.assembly import block, hstack_blocks, coo_features_to_csr
 from conmech.struct.stiffness_matrix import SM3, SM1, SM1to3
 
 DIMENSION = 3
@@ -14,16 +34,24 @@ VOLUME_DIVIDER = 6
 
 
 @numba.njit
-def get_edges_features_matrix_numba(elements, nodes):
-    # integral of phi over the element (in 2D: 1/3, in 3D: 1/4)
-    nodes_count = len(nodes)
-    elements_count, element_size = elements.shape
+def get_edges_features_matrix_coo_numba(elements, nodes):
+    """Assemble node features in COO form.
 
-    edges_features_matrix = np.zeros(
-        (FEATURE_MATRIX_COUNT, nodes_count, nodes_count), dtype=np.double
-    )
+    Contains integral of phi over the element (in 2D: 1/3, in 3D: 1/4).
+    Returns the COO triplets ``(rows, cols, data)`` with ``data`` of shape
+    ``(FEATURE_MATRIX_COUNT, nnz)`` where ``nnz = elements_count * element_size**2``.
+    Duplicate ``(row, col)`` entries are *not* summed here - that is left to
+    ``scipy.sparse`` (which sums duplicates on construction).
+    """
+    elements_count, element_size = elements.shape
+    nnz = elements_count * element_size * element_size
+
+    rows = np.empty(nnz, dtype=np.int64)
+    cols = np.empty(nnz, dtype=np.int64)
+    data = np.zeros((FEATURE_MATRIX_COUNT, nnz), dtype=np.double)
     element_initial_volume = np.zeros(elements_count)
 
+    entry = 0
     for element_index in range(elements_count):  # TODO: #65 prange?
         element = elements[element_index]
         element_nodes = nodes[element]
@@ -50,7 +78,9 @@ def get_edges_features_matrix_numba(elements, nodes):
 
                 w = [[i_d_phi * j_d_phi for j_d_phi in j_d_phi_vec] for i_d_phi in i_d_phi_vec]
 
-                edges_features_matrix[:, element[i], element[j]] += element_volume * np.array(
+                rows[entry] = element[i]
+                cols[entry] = element[j]
+                data[:, entry] = element_volume * np.array(
                     [
                         volume_at_nodes,
                         u,
@@ -68,9 +98,10 @@ def get_edges_features_matrix_numba(elements, nodes):
                         w[2][2],
                     ]
                 )
+                entry += 1
 
     # TODO: #115 compute local_stifness_matrices which should be returned as 3rd value
-    return edges_features_matrix, element_initial_volume, None
+    return rows, cols, data, element_initial_volume, None
 
 
 @numba.njit
@@ -145,7 +176,11 @@ def denominator_numba(x_i, x_j1, x_j2, x_j3):
 
 class DynamicsFactory3D(AbstractDynamicsFactory):
     def get_edges_features_matrix(self, elements, nodes):
-        return get_edges_features_matrix_numba(elements, nodes)
+        rows, cols, data, element_initial_volume, local_stifness_matrices = (
+            get_edges_features_matrix_coo_numba(elements, nodes)
+        )
+        features = coo_features_to_csr(rows, cols, data, len(nodes))
+        return features, element_initial_volume, local_stifness_matrices
 
     @property
     def dimension(self) -> int:
@@ -165,7 +200,7 @@ class DynamicsFactory3D(AbstractDynamicsFactory):
         A_23 = lambda_ * W[2, 1] + mu * W[1, 2]
 
         return SM3(
-            np.block(
+            block(
                 [
                     [A_11, A_12, A_13],
                     [A_21, A_22, A_23],
@@ -175,14 +210,13 @@ class DynamicsFactory3D(AbstractDynamicsFactory):
         )
 
     def calculate_acceleration(self, U, density):
-        Z = np.zeros_like(U)
-        return SM3(density * np.block([[U, Z, Z], [Z, U, Z], [Z, Z, U]]))
+        return SM3(density * block([[U, None, None], [None, U, None], [None, None, U]]))
 
     def calculate_thermal_expansion(self, V, coeff):
         A_11 = coeff[0][0] * V[0] + coeff[0][1] * V[1] + coeff[0][2] * V[2]
         A_22 = coeff[1][0] * V[0] + coeff[1][1] * V[1] + coeff[1][2] * V[2]
         A_33 = coeff[2][0] * V[0] + coeff[2][1] * V[1] + coeff[2][2] * V[2]
-        return SM1to3(np.block([A_11, A_22, A_33]))
+        return SM1to3(hstack_blocks([A_11, A_22, A_33]))
 
     def calculate_thermal_conductivity(self, W, coeff):
         return SM1(

--- a/conmech/dynamics/factory/dynamics_factory_method.py
+++ b/conmech/dynamics/factory/dynamics_factory_method.py
@@ -1,4 +1,23 @@
+# CONMECH @ Jagiellonian University in Kraków
+#
+# Copyright (C) 2022-2026  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 import numpy as np
+from conmech.helpers.assembly import split_features
 from conmech.dynamics.factory._dynamics_factory_2d import DynamicsFactory2D
 from conmech.dynamics.factory._dynamics_factory_3d import DynamicsFactory3D
 from conmech.properties.body_properties import (
@@ -32,19 +51,7 @@ def get_basic_matrices(elements: np.ndarray, nodes: np.ndarray):
         local_stifness_matrices,
     ) = factory.get_edges_features_matrix(elements, nodes)
 
-    volume_at_nodes = edges_features_matrix[0]
-    U = edges_features_matrix[1]
-
-    V = np.asarray([edges_features_matrix[2 + j] for j in range(factory.dimension)])
-    W = np.asarray(
-        [
-            [
-                edges_features_matrix[2 + factory.dimension * (k + 1) + j]
-                for j in range(factory.dimension)
-            ]
-            for k in range(factory.dimension)
-        ]
-    )
+    volume_at_nodes, U, V, W = split_features(edges_features_matrix, factory.dimension)
     return element_initial_volume, volume_at_nodes, U, V, W, local_stifness_matrices
 
 

--- a/conmech/dynamics/statement.py
+++ b/conmech/dynamics/statement.py
@@ -1,3 +1,21 @@
+# CONMECH @ Jagiellonian University in Kraków
+#
+# Copyright (C) 2022-2026  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 from dataclasses import dataclass
 from typing import Optional
 
@@ -38,18 +56,21 @@ class Statement:
         self.apply_dirichlet_condition()
 
     def apply_dirichlet_condition(self):
+        # LIL supports in-place block assignment (CSR does not) and the column
+        # matvec is a sparse @ dense product.
+        data = self.left_hand_side.data.tolil()
         for dirichlet_cond in self.find_dirichlet_conditions():
             c = self.body.mesh.boundaries.boundaries[dirichlet_cond].node_condition
             node_count = self.body.mesh.nodes_count
             for i, j in self.body.mesh.boundaries.get_all_boundary_indices(
                 dirichlet_cond, node_count, self.dimension_in
             ):
-                self.right_hand_side[:] -= self.left_hand_side[:, i] @ c[j]
-                self.left_hand_side.data[:, i] = 0
-                self.left_hand_side.data[i, :] = 0
-                # have to be "[i][:, i]" instead of just a "[i, i]" because the i may be ndarray
-                self.left_hand_side.data[i][:, i] = np.eye(j.stop - j.start)
+                self.right_hand_side[:] -= data[:, i] @ c[j]
+                data[:, i] = 0
+                data[i, :] = 0
+                data[i, i] = np.eye(j.stop - j.start)
                 self.right_hand_side[i] = c[j]
+        self.left_hand_side.data = data.tocsr()
 
     def find_dirichlet_conditions(self):
         boundaries = self.body.mesh.boundaries.boundaries

--- a/conmech/helpers/assembly.py
+++ b/conmech/helpers/assembly.py
@@ -1,0 +1,74 @@
+# CONMECH @ Jagiellonian University in Kraków
+#
+# Copyright (C) 2026  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+"""Helpers bridging numba COO output and ``scipy.sparse`` operators.
+
+numba cannot build ``scipy.sparse`` matrices, so the assembly kernels emit COO
+triplets and the actual sparse matrices are constructed here, outside the
+``numba``.  The block helpers let the operator factories compose block operators
+without caring whether the blocks are dense ``ndarray``s or sparse matrices.
+"""
+
+import scipy.sparse
+
+from conmech.struct.types import FeatureVector, FeatureMatrix
+
+
+def coo_features_to_csr(rows, cols, data, nodes_count):
+    """Turn per-feature COO ``data`` (shape ``(F, nnz)``) into ``F`` CSR blocks.
+
+    ``scipy.sparse.csr_matrix`` sums duplicate ``(row, col)`` entries, which is
+    exactly the accumulation the (former) dense kernel performed explicitly.
+    """
+    feature_count = data.shape[0]
+    return [
+        scipy.sparse.csr_matrix((data[f], (rows, cols)), shape=(nodes_count, nodes_count))
+        for f in range(feature_count)
+    ]
+
+
+def split_features(features, dimension):
+    """Split assembled sparse features into ``(volume_at_nodes, U, V, W)``.
+
+    ``V`` / ``W`` become :class:`FeatureVector` / :class:`FeatureMatrix`
+    wrappers so the operator factories can index them as ``V[i]`` / ``W[i, j]``
+    while the field kind stays explicit.
+    """
+    volume_at_nodes = features[0]
+    u_matrix = features[1]
+    v_vector = FeatureVector([features[2 + j] for j in range(dimension)])
+    w_matrix = FeatureMatrix(
+        [
+            [features[2 + dimension * (k + 1) + j] for j in range(dimension)]
+            for k in range(dimension)
+        ]
+    )
+    return volume_at_nodes, u_matrix, v_vector, w_matrix
+
+
+def block(rows):
+    """Compose a block operator from sparse blocks (``scipy.sparse.bmat``).
+
+    ``None`` entries denote zero blocks, which ``bmat`` understands natively.
+    """
+    return scipy.sparse.bmat(rows, format="csr")
+
+
+def hstack_blocks(blocks):
+    """Horizontal stack of sparse ``(N, N)`` blocks."""
+    return scipy.sparse.hstack(blocks, format="csr")

--- a/conmech/solvers/direct.py
+++ b/conmech/solvers/direct.py
@@ -1,11 +1,27 @@
-"""
-Created at 18.02.2021
-"""
+# CONMECH @ Jagiellonian University in Kraków
+#
+# Copyright (C) 2021-2026  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 
 from typing import Optional, Callable
 
 import numpy as np
 import scipy.optimize
+import scipy.sparse.linalg
 
 from conmech.dynamics.statement import Statement
 from conmech.dynamics.contact.contact_law import DirectContactLaw
@@ -74,15 +90,15 @@ class Direct(Solver):
                     self.body.mesh.nodes,
                     self.body.mesh.contact_boundary,
                     self.body.mesh.boundaries.contact_normals,
-                    self.node_relations,
+                    np.ascontiguousarray(self.node_relations.todense()),
                     self.node_forces,
                     displacement,
-                    self.body.dynamics.acceleration_operator.SM1.data,
+                    self.body.dynamics.acceleration_operator.SM1.bare,
                     self.time_step,
                 ),
             )
         else:
-            result = np.linalg.solve(self.node_relations, self.node_forces)
+            result = scipy.sparse.linalg.spsolve(self.node_relations, self.node_forces)
             result_len = len(result)
             var_len = len(initial_guess.ravel())
             if result_len < var_len:

--- a/conmech/solvers/optimization/global_optimization.py
+++ b/conmech/solvers/optimization/global_optimization.py
@@ -1,6 +1,21 @@
-"""
-Created 22.02.2021
-"""
+# CONMECH @ Jagiellonian University in Kraków
+#
+# Copyright (C) 2021-2026  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 
 import numpy as np
 
@@ -15,7 +30,7 @@ class GlobalOptimization(Optimization):
 
     @property
     def lhs(self) -> np.ndarray:
-        return self.statement.left_hand_side.data
+        return self.statement.left_hand_side.bare
 
     @property
     def rhs(self) -> np.ndarray:

--- a/conmech/solvers/optimization/optimization.py
+++ b/conmech/solvers/optimization/optimization.py
@@ -136,7 +136,7 @@ class Optimization(Solver):
             self.lhs,
             self.rhs if len(self.rhs.shape) == 1 else self.rhs[0],  # TODO
             displacement,
-            np.ascontiguousarray(self.body.dynamics.acceleration_operator.SM1.data),
+            self.body.dynamics.acceleration_operator.SM1.bare,
             self.time_step,
         )
 

--- a/conmech/solvers/optimization/schur_complement.py
+++ b/conmech/solvers/optimization/schur_complement.py
@@ -1,15 +1,49 @@
-"""
-Created at 22.02.2021
-"""
+# CONMECH @ Jagiellonian University in Kraków
+#
+# Copyright (C) 2021-2026  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 
 from typing import Tuple
 
 import numpy as np
+import scipy.sparse
+import scipy.sparse.linalg
 
 from conmech.dynamics.statement import Variables
 from conmech.helpers import nph
 from conmech.solvers._solvers import SolversRegistry
 from conmech.solvers.optimization.optimization import Optimization
+
+
+class FactorizedInverse:
+    """Replacement for an explicit inverse of ``free_x_free``.
+
+    Instead of ``inv(free_x_free)`` (dense) a sparse LU factorization is stored.
+    The ``@`` operator mirrors ``inverse @ rhs`` so no other code has to know
+    whether the inverse is dense sparse.
+    """
+
+    def __init__(self, matrix):
+        # ``splu`` needs CSC
+        self._solver = scipy.sparse.linalg.splu(scipy.sparse.csc_matrix(matrix))
+
+    def __matmul__(self, other):
+        dense = other.toarray() if scipy.sparse.issparse(other) else np.asarray(other)
+        return self._solver.solve(dense)
 
 
 class SchurComplementOptimization(Optimization):
@@ -205,23 +239,33 @@ def calculate_schur_complement_vector(
     return vector_boundary, vector_free
 
 
+def _component_dofs(node_slice: slice, nodes_count: int, dimension: int) -> np.ndarray:
+    nodes = np.arange(nodes_count)[node_slice]
+    return np.concatenate([k * nodes_count + nodes for k in range(dimension)])
+
+
 def calculate_schur_complement_matrices(
-    matrix: np.ndarray, dimension: int, contact_indices: slice, free_indices: slice
+    matrix, dimension: int, contact_indices: slice, free_indices: slice
 ):
-    def get_sliced(matrix_split, indices_height, indices_width):
-        matrix = np.moveaxis(matrix_split[..., indices_height, indices_width], 1, 2)
-        dim, height, _, width = matrix.shape
-        return matrix.reshape(dim * height, dim * width)
+    nodes_count = matrix.shape[0] // dimension
+    matrix = matrix.tocsr()
 
-    matrix_split = np.array(
-        np.split(np.array(np.split(matrix, dimension, axis=-1)), dimension, axis=1)
+    free_dofs = _component_dofs(free_indices, nodes_count, dimension)
+    contact_dofs = _component_dofs(contact_indices, nodes_count, dimension)
+
+    def get_sliced(height_dofs, width_dofs):
+        return matrix[height_dofs][:, width_dofs]
+
+    free_x_free = get_sliced(free_dofs, free_dofs)
+    free_x_contact = get_sliced(free_dofs, contact_dofs)
+    contact_x_free = get_sliced(contact_dofs, free_dofs)
+    contact_x_contact = get_sliced(contact_dofs, contact_dofs)
+
+    free_x_free_inverted = FactorizedInverse(free_x_free)
+    # The reduced (contact-sized) boundary matrix is dense on purpose.
+    # It's small and goes into the optimization functional.
+    matrix_boundary = np.asarray(
+        contact_x_contact.toarray() - contact_x_free @ (free_x_free_inverted @ free_x_contact)
     )
-    free_x_free = get_sliced(matrix_split, free_indices, free_indices)
-    free_x_contact = get_sliced(matrix_split, free_indices, contact_indices)
-    contact_x_free = get_sliced(matrix_split, contact_indices, free_indices)
-    contact_x_contact = get_sliced(matrix_split, contact_indices, contact_indices)
-
-    free_x_free_inverted = np.linalg.inv(free_x_free)
-    matrix_boundary = contact_x_contact - contact_x_free @ (free_x_free_inverted @ free_x_contact)
 
     return matrix_boundary, free_x_contact, contact_x_free, free_x_free_inverted

--- a/conmech/struct/stiffness_matrix.py
+++ b/conmech/struct/stiffness_matrix.py
@@ -1,8 +1,52 @@
+# CONMECH @ Jagiellonian University in Kraków
+#
+# Copyright (C) 2024-2026  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+"""
+Thin wrappers around assembled operator matrices.
+
+The operator matrices are stored as :mod:`scipy.sparse` matrices (assembled in
+COO in numba, composed as CSR outside).  The wrapper keeps the *semantics* of
+the operator explicit outside of ``numba``. The class encodes which field
+the operator acts on (its :attr:`DIMENSION`, e.g. ``(2, 2)`` for a
+2D->2D elasticity operator, ``(1, 2)`` for a scalar-to-2D thermal coupling).
+
+Sparse storage is the only representation kept.  When the bare dense values are
+needed (e.g., a ``numba`` kernel, a dense solver reduced to the contact block)
+they are extracted explicitly via :attr:`bare`, so the compute kernels never
+have to know about the sparse layout.
+"""
+
+import numpy as np
+
+
 class StiffnessMatrix:
     DIMENSION = None
 
     def __init__(self, data):
         self.data = data
+
+    @property
+    def bare(self) -> np.ndarray:
+        """Bare, contiguous dense values.
+
+        ``toarray`` yields a single C-contiguous ndarray (no second copy).
+        """
+        return self.data.toarray(order="C")
 
     def __iadd__(self, other):
         if isinstance(other, StiffnessMatrix):
@@ -10,6 +54,7 @@ class StiffnessMatrix:
             self.data += other.data
         else:
             self.data += other
+        return self
 
     def __add__(self, other):
         if isinstance(other, StiffnessMatrix):
@@ -22,6 +67,7 @@ class StiffnessMatrix:
 
     def __imul__(self, other):
         self.data *= other
+        return self
 
     def __mul__(self, other):
         return type(self)(self.data * other)
@@ -45,6 +91,7 @@ class StiffnessMatrix:
             self.data @= other.data
         else:
             self.data @= other
+        return self
 
     def __rmatmul__(self, other):
         return other @ self.data

--- a/conmech/struct/types.py
+++ b/conmech/struct/types.py
@@ -1,6 +1,6 @@
 # CONMECH @ Jagiellonian University in Kraków
 #
-# Copyright (C) 2024  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
+# Copyright (C) 2024-2026  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -49,10 +49,61 @@ class Tcf64:
 ci64 = Tci64()
 cf64 = Tcf64()
 
+
+# Backend-aware wrappers for assembled node-feature arrays.
+#
+# The FEM assembly (see ``dynamics/factory``) produces, per mesh feature, an
+# ``N x N`` node-to-node matrix.  Grouped together these form the building
+# blocks of every operator:
+#   * ``U``  -- a single ``(N, N)`` mass-like matrix,
+#   * ``V``  -- a ``dim``-vector of ``(N, N)`` matrices (1D field, e.g. thermal
+#               expansion coupling),
+#   * ``W``  -- a ``dim x dim`` matrix of ``(N, N)`` matrices (gradient/gradient
+#               products, the core of every stiffness operator).
+class FeatureVector:
+    """A ``dim``-long vector of assembled ``(N, N)`` blocks."""
+
+    FIELD = 1
+
+    def __init__(self, blocks):
+        self.blocks = list(blocks)
+
+    def __len__(self):
+        return len(self.blocks)
+
+    def __getitem__(self, item):
+        return self.blocks[item]
+
+
+class FeatureMatrix:
+    """A ``dim x dim`` grid of assembled ``(N, N)`` blocks."""
+
+    FIELD = 2
+
+    def __init__(self, blocks):
+        # ``blocks`` is a list of lists (``dim x dim``) of (N, N) matrices.
+        self.blocks = [list(row) for row in blocks]
+        self.dim = len(self.blocks)
+
+    def __getitem__(self, item):
+        if isinstance(item, tuple):
+            i, j = item
+            return self.blocks[i][j]
+        return self.blocks[item]
+
+    def diagonal_sum(self):
+        result = self.blocks[0][0]
+        for i in range(1, self.dim):
+            result = result + self.blocks[i][i]
+        return result
+
+
 __all__ = [
     "ci64",
     "cf64",
     "i64",
     "f64",
     "Tuple",
+    "FeatureVector",
+    "FeatureMatrix",
 ]

--- a/tests/test_conmech/unit_test/test_matrices.py
+++ b/tests/test_conmech/unit_test/test_matrices.py
@@ -1,11 +1,31 @@
+# CONMECH @ Jagiellonian University in Kraków
+#
+# Copyright (C) 2022-2026  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
+# Copyright (C) 2022  Michał Jureczka <michal.jureczka@uj.edu.pl>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 import numpy as np
 
 from conmech.dynamics.factory._dynamics_factory_2d import (
-    get_edges_features_matrix_numba as sut_2d,
+    get_edges_features_matrix_coo_numba as sut_2d,
 )
 from conmech.dynamics.factory._dynamics_factory_3d import (
-    get_edges_features_matrix_numba as sut_3d,
+    get_edges_features_matrix_coo_numba as sut_3d,
 )
+from conmech.helpers.assembly import coo_features_to_csr
 from conmech.dynamics.dynamics import Dynamics
 from conmech.simulations.problem_solver import Body
 from conmech.mesh.mesh import Mesh
@@ -14,6 +34,18 @@ from conmech.properties.mesh_description import (
     RectangleMeshDescription,
     CubeMeshDescription,
 )
+
+
+def _assemble_2d(nodes, elements):
+    rows, cols, data, element_initial_volume, local_stiff = sut_2d(elements=elements, nodes=nodes)
+    features = coo_features_to_csr(rows, cols, data, len(nodes))
+    return features, element_initial_volume, local_stiff
+
+
+def _assemble_3d(nodes, elements):
+    rows, cols, data, element_initial_volume, local_stiff = sut_3d(elements=elements, nodes=nodes)
+    features = coo_features_to_csr(rows, cols, data, len(nodes))
+    return features, element_initial_volume, local_stiff
 
 
 def test_matrices_2d_integrals():
@@ -30,9 +62,7 @@ def test_matrices_2d_integrals():
     )
 
     # Act
-    edges_features_matrix, element_initial_volume, _ = sut_2d(
-        elements=elements, nodes=initial_nodes
-    )
+    edges_features_matrix, element_initial_volume, _ = _assemble_2d(initial_nodes, elements)
 
     # Assert
     np.testing.assert_allclose(element_initial_volume.sum(), area)
@@ -48,7 +78,10 @@ def test_matrices_2d_integrals():
     for M in (*ALL_V, *ALL_W):
         np.testing.assert_almost_equal(M.sum(), 0)
 
-    # TODO: Check Wij = Wji.T
+    # Memory: nnz stored is elements_count * element_size**2, far below N**2.
+    nnz = elements.shape[0] * elements.shape[1] ** 2
+    assert nnz < len(initial_nodes) ** 2
+    assert U.nnz <= nnz
 
 
 def test_matrices_3d_integrals():
@@ -58,9 +91,7 @@ def test_matrices_3d_integrals():
     )
 
     # Act
-    edges_features_matrix, element_initial_volume, _ = sut_3d(
-        elements=elements, nodes=initial_nodes
-    )
+    edges_features_matrix, element_initial_volume, _ = _assemble_3d(initial_nodes, elements)
 
     # Assert
     np.testing.assert_allclose(element_initial_volume.sum(), 1)
@@ -76,7 +107,8 @@ def test_matrices_3d_integrals():
     for M in (*ALL_V, *ALL_W):
         np.testing.assert_almost_equal(M.sum(), 0)
 
-    # TODO: Check Wij = Wji.T
+    nnz = elements.shape[0] * elements.shape[1] ** 2
+    assert nnz < len(initial_nodes) ** 2
 
 
 def test_local_stiff_mats_assembly():
@@ -91,8 +123,10 @@ def test_local_stiff_mats_assembly():
             scale=[scale_x, scale_y],
         )
     )
-    edges_features_matrix, _, local_stiff_mats = sut_2d(elements=elements, nodes=initial_nodes)
-    expected_w_matrix = np.asarray(
+    edges_features_matrix, _, local_stiff_mats = _assemble_2d(initial_nodes, elements)
+    from conmech.struct.types import FeatureMatrix
+
+    expected_w_matrix = FeatureMatrix(
         [
             [edges_features_matrix[2 + dimension * (k + 1) + j] for j in range(dimension)]
             for k in range(dimension)
@@ -115,5 +149,9 @@ def test_local_stiff_mats_assembly():
     # Act
     assembled_w_mat = dynamics.asembly_w_matrix_with_density(density)
 
-    # Assert
-    np.testing.assert_almost_equal(assembled_w_mat, expected_w_matrix)
+    # Assert - identical blocks (density == 1 reproduces the plain W operator)
+    for k in range(dimension):
+        for m in range(dimension):
+            np.testing.assert_almost_equal(
+                assembled_w_mat[k, m].toarray(), expected_w_matrix[k, m].toarray()
+            )

--- a/tests/test_conmech/unit_test/test_sparse_backend.py
+++ b/tests/test_conmech/unit_test/test_sparse_backend.py
@@ -1,0 +1,100 @@
+# CONMECH @ Jagiellonian University in Kraków
+#
+# Copyright (C) 2026  Piotr Bartman-Szwarc <piotr.bartman@uj.edu.pl>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA."""The assembled operators are sparse; check they are correct and Schur agrees
+
+import numpy as np
+import scipy.sparse
+
+from conmech.mesh.mesh import Mesh
+from conmech.simulations.problem_solver import Body
+from conmech.dynamics.dynamics import Dynamics
+from conmech.properties.body_properties import ViscoelasticProperties
+from conmech.scene.body_forces import BodyForces
+from conmech.dynamics.factory.dynamics_factory_method import get_factory
+from conmech.mesh import mesh_builders
+from conmech.properties.mesh_description import RectangleMeshDescription
+from conmech.solvers.optimization.schur_complement import (
+    calculate_schur_complement_matrices,
+)
+
+
+def _build_dynamics():
+    initial_nodes, elements = mesh_builders.build_mesh(
+        mesh_descr=RectangleMeshDescription(
+            initial_position=None, max_element_perimeter=2 / 3, scale=[2, 3]
+        )
+    )
+    mesh = object.__new__(Mesh)
+    mesh.nodes = initial_nodes
+    mesh.elements = elements
+
+    body = object.__new__(Body)
+    body.mesh = mesh
+    body.properties = ViscoelasticProperties(mass_density=1.0, mu=4, lambda_=4, theta=4, zeta=4)
+
+    dynamics = object.__new__(Dynamics)
+    dynamics.body = body
+    body.dynamics = dynamics
+    dynamics.force = BodyForces(body)
+    dynamics.temperature = BodyForces(body)
+    dynamics.factory = get_factory(2)
+    dynamics._Dynamics__relaxation = None
+    dynamics._Dynamics__relaxation_tensor = None
+    dynamics.reinitialize_matrices()
+    return dynamics
+
+
+def test_operators_are_sparse():
+    dynamics = _build_dynamics()
+    for name in ("elasticity", "viscosity", "acceleration_operator"):
+        operator = getattr(dynamics, name)
+        assert scipy.sparse.issparse(operator.data)
+    # Sparsity actually saves memory relative to the dense N**2 storage.
+    assert dynamics.elasticity.data.nnz < np.prod(dynamics.elasticity.data.shape)
+
+
+def test_schur_complement_matches_dense_reference():
+    dynamics = _build_dynamics()
+    matrix = dynamics.elasticity.data  # sparse (2N, 2N)
+    nodes_count = matrix.shape[0] // 2
+    contact = slice(0, 5)
+    free = slice(5, nodes_count)
+
+    boundary, free_x_contact, contact_x_free, free_x_free_inv = calculate_schur_complement_matrices(
+        matrix, 2, contact, free
+    )
+
+    dense = matrix.toarray()
+
+    def dofs(node_slice):
+        nodes = np.arange(nodes_count)[node_slice]
+        return np.concatenate([k * nodes_count + nodes for k in range(2)])
+
+    fd, cd = dofs(free), dofs(contact)
+    ff = dense[np.ix_(fd, fd)]
+    fc = dense[np.ix_(fd, cd)]
+    cf = dense[np.ix_(cd, fd)]
+    cc = dense[np.ix_(cd, cd)]
+    ref_boundary = cc - cf @ np.linalg.solve(ff, fc)
+
+    np.testing.assert_allclose(np.asarray(boundary), ref_boundary, atol=1e-8)
+    np.testing.assert_allclose(free_x_contact.toarray(), fc, atol=1e-10)
+    np.testing.assert_allclose(contact_x_free.toarray(), cf, atol=1e-10)
+
+    rhs = np.arange(fc.shape[0], dtype=float).reshape(-1, 1)
+    np.testing.assert_allclose(free_x_free_inv @ rhs, np.linalg.solve(ff, rhs), atol=1e-8)


### PR DESCRIPTION
Introduces a backend-aware abstraction over assembled FEM operator matrices and use `scipy.sparse` as the only storage backend. Dense values are extracted at the Numba kernel or dense-solver boundaries.

Key changes:
* Added `FeatureVector` and `FeatureMatrix` wrappers. `StiffnessMatrix` now stores operators as sparse m., with `.bare` providing C-contiguous dense arrays.
* Dirichlet conditions are applied entirely on sparse matrices.
* Schur complement operations now use sparse `splu` (`FactorizedInverse`) instead of dense `np.linalg.inv`. Direct linear solves are routed through `scipy.sparse.linalg.spsolve`.
* Introduced type hints (`FeatureMatrix`, `FeatureVector`, `StiffnessMatrix`, `scipy.sparse`) on the factory interfaces.